### PR TITLE
Add timeout to serial connection for error handling

### DIFF
--- a/test.py
+++ b/test.py
@@ -7,32 +7,32 @@ import sys
 pv.debug()
 pv.debug_color()
 
-port = serial.Serial('/dev/tty.usbserial', timeout = 10, write_timeout = 5)
-#port.open()
+	try:
+		port = serial.Serial('/dev/tty.usbserial', timeout = 10, write_timeout = 5)
+		#port.open()
 
-from pv import cms
-inv = cms.Inverter(port)
+		from pv import cms
+		inv = cms.Inverter(port)
 
-inv.reset()
-sn = inv.discover()
-if sn is None:
-	print "Inverter is not connected."
-	sys.exit(1)
-ok = inv.register(sn)		# Associates the inverter and assigns default address
-if not ok:
-	print "Inverter registration failed."
-	sys.exit(1)
+		inv.reset()
+		sn = inv.discover()
+		ok = inv.register(sn)		# Associates the inverter and assigns default address
+		if not ok:
+			print "Inverter registration failed."
+			sys.exit(1)
 
-print inv.version()
+		print inv.version()
 
-param_layout = inv.param_layout()
-parameters = inv.parameters(param_layout)
-for field in parameters:
-	print "%-10s: %s" % field
+		param_layout = inv.param_layout()
+		parameters = inv.parameters(param_layout)
+		for field in parameters:
+			print "%-10s: %s" % field
 
-status_layout = inv.status_layout()
-status = inv.status(status_layout)
-for field in status:
-	print "%-10s: %s" % field
+		status_layout = inv.status_layout()
+		status = inv.status(status_layout)
+		for field in status:
+			print "%-10s: %s" % field
+	except:
+		print("Serial connection did not answer");
 
 port.close()

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ import sys
 pv.debug()
 pv.debug_color()
 
-port = serial.Serial('/dev/tty.usbserial')
+port = serial.Serial('/dev/tty.usbserial', timeout = 10, write_timeout = 5)
 #port.open()
 
 from pv import cms


### PR DESCRIPTION
This is necessary for automating data-download through more than one day, because the inverter "SunEzy 600E" shuts off completely in the night. In order to restart the connection in the morning, you need an way to tell if no response is returned from the inverter. This timeout adds this functionality.  